### PR TITLE
匹配学习通考试的补考,并为日志添加总题目数量

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ ip.txt
 /yatori.db
 /deleteTag.bat
 /.claude/
+.vscode

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -12,5 +12,12 @@ export default defineConfig({
   server: {
     port: 3000,
     open: true,
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
   },
 })

--- a/logic/xuexitong/XueXiTongPart.go
+++ b/logic/xuexitong/XueXiTongPart.go
@@ -220,7 +220,7 @@ func writeCourseWorkAndExam(setting config.Setting, user *config.User, userCache
 				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Red, "拉取考试列表失败,已自动跳过")
 			} else {
 				for _, exam := range examList {
-					if exam.Status != "待做" {
+					if exam.Status != "待做" && exam.Status != "待重考"  {
 						continue
 					}
 					//进入考试
@@ -1226,7 +1226,7 @@ func examAction(userCache *xuexitongApi.XueXiTUserCache, user *config.User, sett
 		if err2 != nil {
 			log.Fatal(err2)
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, fmt.Sprintf("考试状态中,正在回答第%d题", i+1))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, fmt.Sprintf("考试状态中,正在回答第%d题,总共%d题", i+1,exam.QuestionTotal))
 		//内置AI自动写题
 		if user.CoursesCustom.AutoExam == 1 {
 			err3 := question.WriteQuestionForAIAction(userCache, setting.AiSetting.AiUrl, setting.AiSetting.Model, setting.AiSetting.AiType, setting.AiSetting.APIKEY)


### PR DESCRIPTION
1.匹配学习通考试的补考,并为日志添加总题目数量
2.为前端添加反向代理,方便开发
3.过滤vscode配置文件