### PR TITLE
feat: 在控制台中生效配置文件中的 remarkName 备注名字段

### DIFF
--- a/config/Config.go
+++ b/config/Config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/spf13/viper"
 	"github.com/yatori-dev/yatori-go-core/models/ctype"
@@ -80,6 +81,41 @@ type User struct {
 	CoursesCustom CoursesCustom `json:"coursesCustom" yaml:"coursesCustom"`
 }
 
+var (
+	remarkNameLock sync.RWMutex
+	remarkNames    = map[string]string{}
+)
+
+func DisplayAccount(account string) string {
+	remarkNameLock.RLock()
+	defer remarkNameLock.RUnlock()
+	if remarkName, ok := remarkNames[account]; ok {
+		return remarkName
+	}
+	return account
+}
+
+func registerRemarkNames(config *JSONDataForConfig) {
+	remarkNameLock.Lock()
+	defer remarkNameLock.Unlock()
+	remarkNames = map[string]string{}
+	ambiguousAccounts := map[string]struct{}{}
+	for _, user := range config.Users {
+		remarkName := strings.TrimSpace(user.RemarkName)
+		if user.Account != "" && remarkName != "" {
+			if existingRemarkName, ok := remarkNames[user.Account]; ok && existingRemarkName != remarkName {
+				delete(remarkNames, user.Account)
+				ambiguousAccounts[user.Account] = struct{}{}
+				continue
+			}
+			if _, ok := ambiguousAccounts[user.Account]; ok {
+				continue
+			}
+			remarkNames[user.Account] = remarkName
+		}
+	}
+}
+
 // 读取json配置文件
 func ReadJsonConfig(filePath string) JSONDataForConfig {
 	var configJson JSONDataForConfig
@@ -91,6 +127,7 @@ func ReadJsonConfig(filePath string) JSONDataForConfig {
 	if err != nil {
 		log.Fatal(err)
 	}
+	registerRemarkNames(&configJson)
 	return configJson
 }
 
@@ -129,6 +166,7 @@ func ReadConfig(filePath string) JSONDataForConfig {
 	}
 	err = viper.Unmarshal(&configJson)
 	defaultValue(&configJson) //设置默认值
+	registerRemarkNames(&configJson)
 
 	if err != nil {
 		log2.Print(log2.INFO, log2.BoldRed, "配置文件读取失败，请检查配置文件填写是否正确")

--- a/logic/cqie/CqiePart.go
+++ b/logic/cqie/CqiePart.go
@@ -48,7 +48,7 @@ func UserLoginOperation(users []config.User) []*cqieApi.CqieUserCache {
 			cache := &cqieApi.CqieUserCache{Account: user.Account, Password: user.Password}
 			err := cqie.CqieLoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
 			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "["+cache.Account+"] "+" 登录成功")
@@ -74,7 +74,7 @@ func userBlock(setting config.Setting, user *config.User, cache *cqieApi.CqieUse
 	}
 	videosLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -101,7 +101,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *cqieApi
 	//执行刷课---------------------------------
 	nodeList, _ := cqie.PullCourseVideoListAndProgress(userCache, course) //拉取对应课程的视频列表
 	//失效重登检测
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.CourseName+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.CourseName+"】 ")
 	// 提交学时
 	for _, node := range nodeList {
 		//视频处理逻辑
@@ -114,7 +114,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *cqieApi
 			break
 		}
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", "【"+course.CourseName+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", "【"+course.CourseName+"】 ", "学习完毕")
 
 }
 
@@ -124,7 +124,7 @@ func videoAction(setting config.Setting, user *config.User, UserCache *cqieApi.C
 		return
 	}
 
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, "【"+node.VideoName+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, "【"+node.VideoName+"】 ")
 	nowTime := time.Now()
 	startPos := node.StudyTime
 	stopPos := node.StudyTime
@@ -145,18 +145,18 @@ func videoAction(setting config.Setting, user *config.User, UserCache *cqieApi.C
 		}
 		err := cqie.SubmitStudyTimeAction(UserCache, &node, nowTime, startPos, stopPos, maxPos)
 		if err != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "提交学时异常：", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "提交学时异常：", err.Error())
 		}
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "【"+node.VideoName+"】  >>> ", "提交状态：", "成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float32(node.StudyTime)/float32(node.TimeLength)), "%")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "【"+node.VideoName+"】  >>> ", "提交状态：", "成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float32(node.StudyTime)/float32(node.TimeLength)), "%")
 		startPos = startPos + 3
 		stopPos = stopPos + 3
 		time.Sleep(3 * time.Second)
 	}
 	err = cqie.SaveVideoStudyTimeAction(UserCache, &node, startPos, stopPos) //学完之后保存学习点
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "保存学习点异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "保存学习点异常：", err.Error())
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.VideoName+"】 ", lg.Green, "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.VideoName+"】 ", lg.Green, "学习完毕")
 }
 
 // videoAction 刷视频逻辑抽离(秒刷版本)
@@ -174,11 +174,11 @@ func videoActionSecondBrush(setting config.Setting, user *config.User, UserCache
 	}
 	err1 := cqie.SubmitStudyTimeAction(UserCache, &node, nowTime, startPos, stopPos, maxPos)
 	if err1 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "提交学时异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "提交学时异常：", err.Error())
 	}
 	err = cqie.SaveVideoStudyTimeAction(UserCache, &node, startPos, stopPos) //学完之后保存学习点
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "保存学习点异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "【"+node.VideoName+"】", lg.BoldRed, "保存学习点异常：", err.Error())
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.VideoName+"】 ", lg.Green, "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.VideoName+"】 ", lg.Green, "学习完毕")
 }

--- a/logic/enaea/EnaeaPart.go
+++ b/logic/enaea/EnaeaPart.go
@@ -50,7 +50,7 @@ func UserLoginOperation(users []config.User) []*enaeaApi.EnaeaUserCache {
 			cache := &enaeaApi.EnaeaUserCache{Account: user.Account, Password: user.Password}
 			_, err := enaea.EnaeaLoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
 			UserCaches = append(UserCaches, cache)
@@ -92,10 +92,10 @@ func userBlock(setting config.Setting, user *config.User, cache *enaeaApi.EnaeaU
 		}
 		courseList, err := enaea.CourseListAction(cache, course.CircleId)
 		if err != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.BoldRed, "拉取项目列表错误", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.BoldRed, "拉取项目列表错误", err.Error())
 			os.Exit(0)
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "正在学习项目", " 【"+course.ClusterName+"】 ")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "正在学习项目", " 【"+course.ClusterName+"】 ")
 
 		excludeTitleTag := []string{}
 		includeTitleTag := []string{}
@@ -124,7 +124,7 @@ func userBlock(setting config.Setting, user *config.User, cache *enaeaApi.EnaeaU
 		}
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -148,13 +148,13 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *enaeaAp
 		nodeList = nodeList1
 		err = err1
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.TitleTag+"】", "【"+course.CourseTitle+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.TitleTag+"】", "【"+course.CourseTitle+"】 ")
 	// 提交学时
 	for _, node := range nodeList {
 		//视频处理逻辑
 		videoAction(setting, user, userCache, node)
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", " 【"+course.TitleTag+"】", "【"+course.CourseTitle+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", " 【"+course.TitleTag+"】", "【"+course.CourseTitle+"】 ", "学习完毕")
 
 }
 
@@ -164,14 +164,14 @@ func videoAction(setting config.Setting, user *config.User, UserCache *enaeaApi.
 		return
 	}
 
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, " 【"+node.TitleTag+"】", "【"+node.CourseName+"】", "【"+node.CourseContentStr+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, " 【"+node.TitleTag+"】", "【"+node.CourseName+"】", "【"+node.CourseContentStr+"】 ")
 	err := enaea.StatisticTicForCCVideAction(UserCache, &node)
 	if err != nil {
 		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), `[`, UserCache.Account, `] `, lg.BoldRed, "提交学时接口访问异常，返回信息：", err.Error())
 	}
 	for {
 		if node.StudyProgress >= 100 {
-			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", " 【"+node.TitleTag+"】", " 【"+node.CourseName+"】", "【"+node.CourseContentStr+"】", " ", lg.Blue, "学习完毕")
+			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", " 【"+node.TitleTag+"】", " 【"+node.CourseName+"】", "【"+node.CourseContentStr+"】", " ", lg.Blue, "学习完毕")
 			break //如果看完了，也就是进度为100那么直接跳过
 		}
 		//提交学时
@@ -190,7 +190,7 @@ func videoAction(setting config.Setting, user *config.User, UserCache *enaeaApi.
 		//失效重登检测
 		enaea.LoginTimeoutAfreshAction(UserCache, err)
 
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", " 【"+node.TitleTag+"】", "【"+node.CourseName+"】", "【"+node.CourseContentStr+"】  >>> ", "提交状态：", "成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", node.StudyProgress), "%")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", " 【"+node.TitleTag+"】", "【"+node.CourseName+"】", "【"+node.CourseContentStr+"】  >>> ", "提交状态：", "成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", node.StudyProgress), "%")
 		time2.Sleep(25 * time2.Second) //每隔25s进行一次学时提交
 		if node.StudyProgress >= 100 {
 			break //如果看完该视频则直接下一个

--- a/logic/haiqikeji/HqkjPart.go
+++ b/logic/haiqikeji/HqkjPart.go
@@ -51,7 +51,7 @@ func UserLoginOperation(users []config.User) []*hqkjApi.HqkjUserCache {
 			cache := &hqkjApi.HqkjUserCache{PreUrl: user.URL, Account: user.Account, Password: user.Password}
 			err := haiqikeji.HqkjLoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
 			UserCaches = append(UserCaches, cache)
@@ -84,7 +84,7 @@ func userBlock(setting config.Setting, user *config.User, cache *hqkjApi.HqkjUse
 	}
 	coursesLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -109,7 +109,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *hqkjApi
 		return
 	}
 	if course.StartDate.After(time.Now()) || course.EndDate.Before(time.Now()) { //过滤掉过时课程
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】 >>> ", lg.Default, " ", "该课程的起止时间为：", lg.Red, fmt.Sprintf("[%s ~ %s] ", course.StartDate.Format("2006-01-02"), course.EndDate.Format("2006-01-02")), lg.Yellow, "因未在开课时间内，已跳过该课程")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】 >>> ", lg.Default, " ", "该课程的起止时间为：", lg.Red, fmt.Sprintf("[%s ~ %s] ", course.StartDate.Format("2006-01-02"), course.EndDate.Format("2006-01-02")), lg.Yellow, "因未在开课时间内，已跳过该课程")
 		return
 	}
 	//执行刷课---------------------------------
@@ -119,7 +119,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *hqkjApi
 		return
 	}
 	//nodeList := ketangx.PullNodeListAction(userCache, course) //拉取对应课程的视频列表
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, " 【"+course.Name+"】 ")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, " 【"+course.Name+"】 ")
 	//视频处理逻辑
 	switch user.CoursesCustom.VideoModel {
 	case 1:
@@ -130,7 +130,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *hqkjApi
 		break
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", "【"+course.Name+"】 ", "学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", "【"+course.Name+"】 ", "学习完毕")
 
 }
 
@@ -176,9 +176,9 @@ func normalModeAction(setting config.Setting, user *config.User, UserCache *hqkj
 			}
 			msg := gojsonq.New().JSONString(submitResult).Find("msg")
 			if msg != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg").(string), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(submitProgress)), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg").(string), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(submitProgress)), "%")
 			} else {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg"), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(submitProgress)), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg"), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(submitProgress)), "%")
 			}
 			if err != nil {
 				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "拉取进度错误", err.Error())
@@ -189,7 +189,7 @@ func normalModeAction(setting config.Setting, user *config.User, UserCache *hqkj
 			if submitProgress >= 100 {
 				//保存结果
 				endResult, err := haiqikeji.HqkjEndStudyAction(UserCache, sessionId)
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", lg.Default, " ", "服务器返回：", endResult)
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", lg.Default, " ", "服务器返回：", endResult)
 				if err != nil {
 					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), err.Error())
 					break
@@ -248,10 +248,10 @@ func fastModeAction(setting config.Setting, user *config.User, UserCache *hqkjAp
 					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "提交学时失败：", err.Error())
 					return
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg").(string), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(100)), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", "提交状态：", lg.Green, gojsonq.New().JSONString(submitResult).Find("msg").(string), lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float64(100)), "%")
 				//保存结果
 				endResult, err := haiqikeji.HqkjEndStudyAction(UserCache, sessionId)
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", lg.Default, " ", "服务器返回：", endResult)
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", "【", course.Name, "】", "【", node.Name, "】 >>> ", lg.Default, " ", "服务器返回：", endResult)
 				if err != nil {
 					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), err.Error())
 					break
@@ -285,13 +285,13 @@ func videoAction(setting config.Setting, user *config.User, UserCache *ketangxAp
 	}
 	action, err := ketangx.CompleteVideoAction(UserCache, &node)
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", err.Error())
 		return
 	}
 	status := gojsonq.New().JSONString(action).Find("Success")
 	if status != nil && !status.(bool) {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", action)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", action)
 		return
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", "结点类型: ", "<", lg.Yellow, node.Type, lg.Default, "> ", lg.Green, "学习完毕，服务器返回状态:"+strconv.FormatBool(status.(bool)))
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", "结点类型: ", "<", lg.Yellow, node.Type, lg.Default, "> ", lg.Green, "学习完毕，服务器返回状态:"+strconv.FormatBool(status.(bool)))
 }

--- a/logic/icve/IcvePart.go
+++ b/logic/icve/IcvePart.go
@@ -48,20 +48,20 @@ func UserLoginOperation(users []config.User) []*icve.IcveUserCache {
 				cache := &icve.IcveUserCache{Account: user.Account, Password: user.Password}
 				err := action.IcveCookieLogin(cache)
 				if err != nil {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Red, err.Error())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Red, err.Error())
 					log.Fatal(err) //登录失败则直接退出
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Green, "登录成功")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Green, "登录成功")
 				UserCaches = append(UserCaches, cache)
 			} else {
 				cache := &icve.IcveUserCache{Account: user.Account, Password: user.Password}
 
 				err := action.IcveLoginAction(cache)
 				if err != nil {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Red, err.Error())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Red, err.Error())
 					log.Fatal(err) //登录失败则直接退出
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Green, "登录成功")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Green, "登录成功")
 				UserCaches = append(UserCaches, cache)
 			}
 
@@ -88,7 +88,7 @@ func userBlock(setting config.Setting, user *config.User, cache *icve.IcveUserCa
 	}
 	videosLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -114,13 +114,13 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *icve.Ic
 	}
 	//如果课程已结束，那么直接跳过
 	if course.Status == "3" {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Yellow, "【"+course.CourseName+"】 ", "该课程已结束，已自动跳过...")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Yellow, "【"+course.CourseName+"】 ", "该课程已结束，已自动跳过...")
 		return
 	}
 	//执行刷课---------------------------------
 
 	//失效重登检测
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.CourseName+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.CourseName+"】 ")
 	// 提交学时
 	chapterList, err := action.PullZYKCourseNodeAction(userCache, *course) //拉取对应课程的章节
 	if err != nil {
@@ -134,7 +134,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *icve.Ic
 			break
 		}
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", "【"+course.CourseName+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", "【"+course.CourseName+"】 ", "学习完毕")
 
 }
 
@@ -149,9 +149,9 @@ func nodeCompleteAction(setting config.Setting, user *config.User, UserCache *ic
 	}
 	submitResult, err2 := action.SubmitZYKStudyTimeAction(UserCache, node)
 	if err2 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.CourseName+"】 ", "【"+node.Name+"】", lg.BoldRed, "学习异常：", err2.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.CourseName+"】 ", "【"+node.Name+"】", lg.BoldRed, "学习异常：", err2.Error())
 		return
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.CourseName+"】 ", "【"+node.Name+"】", lg.Green, "学习完毕,学习状态：", submitResult)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.CourseName+"】 ", "【"+node.Name+"】", lg.Green, "学习完毕,学习状态：", submitResult)
 }

--- a/logic/ketangx/KetangxPart.go
+++ b/logic/ketangx/KetangxPart.go
@@ -49,7 +49,7 @@ func UserLoginOperation(users []config.User) []*ketangxApi.KetangxUserCache {
 			cache := &ketangxApi.KetangxUserCache{Account: user.Account, Password: user.Password}
 			err := ketangx.LoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
 			UserCaches = append(UserCaches, cache)
@@ -74,7 +74,7 @@ func userBlock(setting config.Setting, user *config.User, cache *ketangxApi.Keta
 	}
 	videosLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -101,7 +101,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *ketangx
 	//执行刷课---------------------------------
 	nodeList := ketangx.PullNodeListAction(userCache, course) //拉取对应课程的视频列表
 	//失效重登检测
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.Title+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.Title+"】 ")
 	// 提交学时
 	for _, node := range nodeList {
 		//视频处理逻辑
@@ -111,7 +111,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *ketangx
 			break
 		}
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", "【"+course.Title+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", "【"+course.Title+"】 ", "学习完毕")
 
 }
 
@@ -125,16 +125,16 @@ func videoAction(setting config.Setting, user *config.User, UserCache *ketangxAp
 	}
 	action, err := ketangx.CompleteVideoAction(UserCache, &node)
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", err.Error())
 		return
 	}
 	status := gojsonq.New().JSONString(action).Find("Success")
 	if status != nil && !status.(bool) {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", action)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", lg.BoldRed, "结点类型: ", "<", node.Type, "> ", "学习异常：", action)
 		return
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", "结点类型: ", "<", lg.Yellow, node.Type, lg.Default, "> ", lg.Green, "学习完毕，服务器返回状态:"+strconv.FormatBool(status.(bool)))
-	//modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO,fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]),"[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, "【"+node.Title+"】 ")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Title+"】 ", "【"+node.Title+"】", "结点类型: ", "<", lg.Yellow, node.Type, lg.Default, "> ", lg.Green, "学习完毕，服务器返回状态:"+strconv.FormatBool(status.(bool)))
+	//modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO,fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]),"[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, "【"+node.Title+"】 ")
 
-	//modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO,fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]),"[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.Title+"】 ", lg.Green, "学习完毕")
+	//modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO,fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]),"[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "视频：", lg.Default, "【"+node.Title+"】 ", lg.Green, "学习完毕")
 }

--- a/logic/qingshuxuetang/QsxtPart.go
+++ b/logic/qingshuxuetang/QsxtPart.go
@@ -48,10 +48,10 @@ func UserLoginOperation(users []config.User) []*qsxt.QsxtUserCache {
 			cache := &qsxt.QsxtUserCache{Account: user.Account, Password: user.Password}
 			_, err := action.QsxtLoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Green, "登录成功")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Green, "登录成功")
 			UserCaches = append(UserCaches, cache)
 		}
 	}
@@ -75,7 +75,7 @@ func userBlock(setting config.Setting, user *config.User, cache *qsxt.QsxtUserCa
 	}
 	videosLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -103,7 +103,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *qsxt.Qs
 		return
 	}
 	//执行刷课---------------------------------
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "]", "【", course.CourseName, "】", lg.Purple, "正在学习该课程")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "]", "【", course.CourseName, "】", lg.Purple, "正在学习该课程")
 	//nodeList := ketangx.PullNodeListAction(userCache, course) //拉取对应课程的视频列表
 	//分数不够且视频模式是开启的情况下才进行学习
 	if user.CoursesCustom.VideoModel != 0 {
@@ -158,7 +158,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *qsxt.Qs
 			nodeWorkAction(setting, user, userCache, course, &work)
 		}
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "]", "【"+course.CourseName+"】", lg.Green, "课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "]", "【"+course.CourseName+"】", lg.Green, "课程学习完毕")
 
 }
 
@@ -181,19 +181,19 @@ func nodeSubmitTimeAction(user *config.User, cache *qsxt.QsxtUserCache, course *
 
 	startId, err2 := node.StartStudyTimeAction(cache)
 	if err2 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "开始学习接口异常：", err2.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "开始学习接口异常：", err2.Error())
 	}
 
 	studyTime := 0                 //当前累计学习了多久
 	maxTime := endTime - totalTime //最大学习多长时间
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "正在开始学习,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", startId)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "正在开始学习,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", startId)
 	for {
 		time.Sleep(60 * time.Second)
 		submitResult, err3 := node.SubmitStudyTimeAction(cache, startId, false)
 		if err3 != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "学习异常：", err3.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "学习异常：", err3.Error())
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "学时提交成功,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", submitResult)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "学时提交成功,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", submitResult)
 		studyTime += 60
 		if studyTime >= maxTime {
 			break
@@ -201,10 +201,10 @@ func nodeSubmitTimeAction(user *config.User, cache *qsxt.QsxtUserCache, course *
 	}
 	submitResult, err3 := node.SubmitStudyTimeAction(cache, startId, true)
 	if err3 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "结束学习接口异常：", err3.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.BoldRed, "结束学习接口异常：", err3.Error())
 	}
 	action.UpdateCourseScore(cache, course) //看完一个视频就更新一次分数
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "学习完毕,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", submitResult)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.NodeName+"】", lg.Green, "学习完毕,进度: ", fmt.Sprintf("%d/%d", studyTime+totalTime, endTime), ",服务器返回信息: ", submitResult)
 }
 
 // 作业
@@ -212,7 +212,7 @@ func nodeWorkAction(setting config.Setting, user *config.User, cache *qsxt.QsxtU
 	if work.AnswerStatus == 2 { //如果答过了则直接退出
 		return
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.Yellow, "正在自动完成作业... ")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.Yellow, "正在自动完成作业... ")
 	submitStatus := false
 	if user.CoursesCustom.ExamAutoSubmit == 0 {
 		submitStatus = false
@@ -221,10 +221,10 @@ func nodeWorkAction(setting config.Setting, user *config.User, cache *qsxt.QsxtU
 	}
 	submitResult, err3 := action.WriteWorkAction(cache, *work, submitStatus)
 	if err3 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.BoldRed, "作业提交异常：", err3.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.BoldRed, "作业提交异常：", err3.Error())
 	}
 	action.UpdateCourseScore(cache, course) //答完一个作业就更新一次分数
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.Green, "作业已自动完成,服务器返回信息: ", submitResult)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+work.Title+"】", lg.Green, "作业已自动完成,服务器返回信息: ", submitResult)
 }
 
 // 资料累计学时
@@ -232,11 +232,11 @@ func materialSubmitTimeAction(user *config.User, cache *qsxt.QsxtUserCache, cour
 
 	startId, err2 := node.StartStudyTimeAction(cache)
 	if err2 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "资料文件开始学习接口异常：", err2.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "资料文件开始学习接口异常：", err2.Error())
 	}
 
 	studyTime := 0 //当前累计学习了多久
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "正在开始学习资料文件,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", startId)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "正在开始学习资料文件,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", startId)
 	for {
 		//如果分数以及满了则直接退出
 		if course.CourseMaterialsLearnGainCore >= course.CourseMaterialsLearnTotalCore {
@@ -245,16 +245,16 @@ func materialSubmitTimeAction(user *config.User, cache *qsxt.QsxtUserCache, cour
 		time.Sleep(60 * time.Second)
 		submitResult, err3 := node.SubmitStudyTimeAction(cache, startId, false)
 		if err3 != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "资料文件学习异常：", err3.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "资料文件学习异常：", err3.Error())
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "资料文件学时提交成功,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", submitResult)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "资料文件学时提交成功,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", submitResult)
 		studyTime += 60
 		action.UpdateCourseScore(cache, course) //看完一个视频就更新一次分数
 	}
 	submitResult, err3 := node.SubmitStudyTimeAction(cache, startId, true)
 	if err3 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "结束资料文件学习接口异常：", err3.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.BoldRed, "结束资料文件学习接口异常：", err3.Error())
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "资料文件学习完毕,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", submitResult)
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "]", lg.Default, "【"+course.CourseName+"】", "【"+node.Name+"】", lg.Green, "资料文件学习完毕,学习时长: ", fmt.Sprintf("%d", studyTime), ",服务器返回信息: ", submitResult)
 }

--- a/logic/welearn/WeLearnPart.go
+++ b/logic/welearn/WeLearnPart.go
@@ -51,10 +51,10 @@ func UserLoginOperation(users []config.User) []*welearn.WeLearnUserCache {
 			cache := &welearn.WeLearnUserCache{Account: user.Account, Password: user.Password}
 			err := action.WeLearnLoginAction(cache) // 登录
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err.Error())
 				log.Fatal(err) //登录失败则直接退出
 			}
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Green, "登录成功")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Green, "登录成功")
 			UserCaches = append(UserCaches, cache)
 		}
 	}
@@ -80,7 +80,7 @@ func userBlock(setting config.Setting, user *config.User, cache *welearn.WeLearn
 	}
 	videosLock.Wait() //等待课程刷完
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -108,7 +108,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *welearn
 
 	//nodeList := ketangx.PullNodeListAction(userCache, course) //拉取对应课程的视频列表
 	//失效重登检测
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.Name+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, "【"+course.Name+"】 ")
 	// 提交学时
 	chapterList, err := action.WeLearnPullCourseChapterAction(userCache, *course) //拉取对应课程的章节
 	if err != nil {
@@ -130,7 +130,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *welearn
 			}
 		}
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", "【"+course.Name+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", "【"+course.Name+"】 ", "学习完毕")
 
 }
 
@@ -140,7 +140,7 @@ func nodeCompleteAction(setting config.Setting, user *config.User, UserCache *we
 		return
 	}
 	if !node.IsVisible {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Yellow, "该任务点还未解锁，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Yellow, "该任务点还未解锁，已自动跳过")
 		return
 	}
 	//如果完成了的直接跳过
@@ -150,11 +150,11 @@ func nodeCompleteAction(setting config.Setting, user *config.User, UserCache *we
 	//action, err := ketangx.CompleteVideoAction(UserCache, &node)
 	err := action.WeLearnCompletePointAction(UserCache, *course, node)
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.BoldRed, "学习异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.BoldRed, "学习异常：", err.Error())
 		return
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学习完毕")
 
 }
 
@@ -164,7 +164,7 @@ func nodeSubmitTimeAction(setting config.Setting, user *config.User, UserCache *
 		return
 	}
 	if !node.IsVisible {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Yellow, "该任务点还未解锁，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Yellow, "该任务点还未解锁，已自动跳过")
 		return
 	}
 	//如果完成了的直接跳过
@@ -182,12 +182,12 @@ func nodeSubmitTimeAction(setting config.Setting, user *config.User, UserCache *
 	if learnTime != "" {
 		a, err1 := strconv.Atoi(strings.Split(learnTime, "-")[0])
 		if err1 != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "大哥，你", UserCache.Account, "账号的weLearnTime配置写错了，注意是xx-xx范围，当然xxx到xxx也都可以，但是xx必须是整数数字，并且前面部分的xx要大于后面的xx")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "大哥，你", UserCache.Account, "账号的weLearnTime配置写错了，注意是xx-xx范围，当然xxx到xxx也都可以，但是xx必须是整数数字，并且前面部分的xx要大于后面的xx")
 			panic("")
 		}
 		b, err2 := strconv.Atoi(strings.Split(learnTime, "-")[1])
 		if err2 != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", "大哥，你", UserCache.Account, "账号的weLearnTime配置写错了，注意是xx-xx范围，当然xxx到xxx也都可以，但是xx必须是整数数字，并且前面部分的xx要大于后面的xx")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", "大哥，你", UserCache.Account, "账号的weLearnTime配置写错了，注意是xx-xx范围，当然xxx到xxx也都可以，但是xx必须是整数数字，并且前面部分的xx要大于后面的xx")
 			panic("")
 		}
 		endTime = (rand.Intn(b-a+1) + a) * 60 // 生成100到999之间的随机数
@@ -202,7 +202,7 @@ func nodeSubmitTimeAction(setting config.Setting, user *config.User, UserCache *
 			fmt.Println(err1)
 		}
 		//fmt.Println(totalTime, api)
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学时提交成功，进度: ", fmt.Sprintf("%d/%d", totalTime, endTime), "服务器返回信息: ", api)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学时提交成功，进度: ", fmt.Sprintf("%d/%d", totalTime, endTime), "服务器返回信息: ", api)
 		if sessionTime >= endTime {
 			break
 		}
@@ -217,10 +217,10 @@ func nodeSubmitTimeAction(setting config.Setting, user *config.User, UserCache *
 	//fmt.Println(submitApi2)
 
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.BoldRed, "学习异常：", err.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.BoldRed, "学习异常：", err.Error())
 		return
 	}
 
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Default, "【"+course.Name+"】 ", "【"+node.Location+"】", lg.Green, "学习完毕")
 
 }

--- a/logic/xuexitong/XueXiTongPart.go
+++ b/logic/xuexitong/XueXiTongPart.go
@@ -90,7 +90,7 @@ func UserBlock(setting config.Setting, user *config.User, cache *xuexitongApi.Xu
 	// list, err := xuexitong.XueXiTCourseDetailForCourseIdAction(cache, "261619055656961")
 	courseList, err := xuexitong.XueXiTPullCourseAction(cache)
 	if err != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", lg.Red, "拉取课程失败")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", lg.Red, "拉取课程失败")
 		log.Fatal(err)
 	}
 	//如果是多节点模式
@@ -100,9 +100,9 @@ func UserBlock(setting config.Setting, user *config.User, cache *xuexitongApi.Xu
 			num = *user.CoursesCustom.CxNode
 		}
 		if *user.CoursesCustom.CxNode == -1 {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", lg.Yellow, "警告，当前账号使用的是多任务点无限制模式，该账号将会同时登录非常多的次数，这将会小概率性封号(一般封十几分钟)或封IP，单个账号使用基本没有事，多个账号请酌情使用")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", lg.Yellow, "警告，当前账号使用的是多任务点无限制模式，该账号将会同时登录非常多的次数，这将会小概率性封号(一般封十几分钟)或封IP，单个账号使用基本没有事，多个账号请酌情使用")
 		} else {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", lg.Yellow, "警告，当前账号使用的是多任务点模式，该账号将会同时登录", fmt.Sprintf("%d", num), "次，这将会小概率性封号(一般封十几分钟)或封IP，单个账号使用基本没有事，多个账号请酌情使用")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", lg.Yellow, "警告，当前账号使用的是多任务点模式，该账号将会同时登录", fmt.Sprintf("%d", num), "次，这将会小概率性封号(一般封十几分钟)或封IP，单个账号使用基本没有事，多个账号请酌情使用")
 		}
 
 		//如果没有则初始化
@@ -116,7 +116,7 @@ func UserBlock(setting config.Setting, user *config.User, cache *xuexitongApi.Xu
 			}
 			model3Caches[cache.Name] = append(model3Caches[cache.Name], *cache)
 			xuexitong.ReLogin(&model3Caches[cache.Name][i])
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "当前多任务点账户队列累计", lg.Yellow, fmt.Sprintf("%d/%d", i+1, num))
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "当前多任务点账户队列累计", lg.Yellow, fmt.Sprintf("%d/%d", i+1, num))
 			time.Sleep(1 * time.Second) //隔一下，避免登录太快
 		}
 
@@ -137,7 +137,7 @@ func UserBlock(setting config.Setting, user *config.User, cache *xuexitongApi.Xu
 
 	}
 	nodesLock.Wait()
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
 		utils2.SendMail(setting.EmailInform.SMTPHost, setting.EmailInform.SMTPPort, setting.EmailInform.UserName, setting.EmailInform.Password, user.InformEmails, fmt.Sprintf("账号：[%s]</br>平台：[%s]</br>通知：所有课程已执行完毕", user.Account, global.AccountTypeStr[user.AccountType]))
@@ -162,7 +162,7 @@ func courseStudy(setting config.Setting, user *config.User, userCache *xuexitong
 	}
 	//如果课程还未开课则直接退出
 	if !courseItem.IsStart {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Blue, "该课程还未开课，已自动跳过该课程")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Blue, "该课程还未开课，已自动跳过该课程")
 		return
 	}
 
@@ -170,7 +170,7 @@ func courseStudy(setting config.Setting, user *config.User, userCache *xuexitong
 	chapterStudy(setting, user, userCache, courseItem)
 	//写课程的作业和考试
 	writeCourseWorkAndExam(setting, user, userCache, courseItem)
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Purple, "课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Purple, "课程学习完毕")
 }
 
 // 写课程
@@ -194,7 +194,7 @@ func writeCourseWorkAndExam(setting config.Setting, user *config.User, userCache
 			workList, err1 := xuexitong.PullWorkListAction(userCache, *courseItem)
 			if err1 != nil {
 				//log.Fatal(err1)
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Red, "拉取作业列表失败,已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Red, "拉取作业列表失败,已自动跳过")
 
 			} else {
 				for _, work := range workList {
@@ -205,7 +205,7 @@ func writeCourseWorkAndExam(setting config.Setting, user *config.User, userCache
 					err2 := xuexitong.EnterWorkAction(userCache, &work)
 					if err2 != nil {
 						if strings.Contains(err2.Error(), "已过时效，不能操作!") {
-							lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "该作业已过时，已自动跳过该作业...")
+							lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "该作业已过时，已自动跳过该作业...")
 							continue
 						}
 						log.Fatal(err2)
@@ -219,7 +219,7 @@ func writeCourseWorkAndExam(setting config.Setting, user *config.User, userCache
 			//拉取考试列表
 			examList, err1 := xuexitong.PullExamListAction(userCache, *courseItem)
 			if err1 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Red, "拉取考试列表失败,已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Red, "拉取考试列表失败,已自动跳过")
 			} else {
 				for _, exam := range examList {
 					if exam.Status != "待做" && exam.Status != "待重考" {
@@ -254,14 +254,14 @@ func chapterStudy(setting config.Setting, user *config.User, userCache *xuexiton
 
 		if err != nil {
 			if strings.Contains(err.Error(), "课程章节为空") {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该课程章节为空已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该课程章节为空已自动跳过")
 				return
 			}
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "拉取章节信息接口访问异常，若需要继续可以配置中添加排除此异常课程。返回信息：", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "拉取章节信息接口访问异常，若需要继续可以配置中添加排除此异常课程。返回信息：", err.Error())
 			return
 			//log.Fatal()
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, "获取课程章节成功 (共 ", lg.Yellow, strconv.Itoa(len(action.Knowledge)), lg.Default, " 个) ")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, "获取课程章节成功 (共 ", lg.Yellow, strconv.Itoa(len(action.Knowledge)), lg.Default, " 个) ")
 
 		var nodes []int
 		for _, item := range action.Knowledge {
@@ -273,7 +273,7 @@ func chapterStudy(setting config.Setting, user *config.User, userCache *xuexiton
 		// 检测节点完成情况
 		pointAction, err := xuexitong.ChapterFetchPointAction(userCache, nodes, &action, key, userId, courseItem.Cpi, courseId)
 		if err != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "探测节点完成情况接口访问异常，若需要继续可以配置中添加排除此异常课程。返回信息：", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "探测节点完成情况接口访问异常，若需要继续可以配置中添加排除此异常课程。返回信息：", err.Error())
 			//log.Fatal()
 			return
 		}
@@ -286,13 +286,13 @@ func chapterStudy(setting config.Setting, user *config.User, userCache *xuexiton
 				//如果是0任务点，则直接浏览一遍主页面即可完成任务，不必继续下去
 				err2 := xuexitong.EnterChapterForwardCallAction(userCache, strconv.Itoa(courseId), strconv.Itoa(key), strconv.Itoa(pointAction.Knowledge[index].ID), strconv.Itoa(courseItem.Cpi))
 				if err2 != nil {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "零任务点遍历失败。返回信息：", err2.Error())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "零任务点遍历失败。返回信息：", err2.Error())
 				}
 			}
 			return i.PointTotal >= 0 && i.PointTotal == i.PointFinished
 		}
 
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Purple, "正在学习该课程")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "[", courseItem.CourseName, "] ", lg.Purple, "正在学习该课程")
 		//初始化模式3用的队列
 		queue := make(chan int, len(model3Caches[userCache.Name]))
 		for i := 0; i < len(model3Caches[userCache.Name]); i++ {
@@ -339,13 +339,13 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 	pointAction xuexitong.ChaptersList, action xuexitong.ChaptersList, nodes []int, index int, key int, courseId int) {
 	_, fetchCards, err1 := xuexitong.ChapterFetchCardsAction(userCache, &action, nodes, index, courseId, key, courseItem.Cpi)
 	if err1 != nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "无法正常拉取卡片信息，请联系作者查明情况,报错信息：", err1.Error())
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "无法正常拉取卡片信息，请联系作者查明情况,报错信息：", err1.Error())
 		return
 	}
 
 	videoDTOs, workDTOs, documentDTOs, hyperlinkDTOs, liveDTOs, bbsDTOs := xuexitongApi.ParsePointDto(fetchCards)
 	if videoDTOs == nil && workDTOs == nil && documentDTOs == nil && hyperlinkDTOs == nil && liveDTOs == nil && bbsDTOs == nil {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, `[`, pointAction.Knowledge[index].Name, `] `, lg.Blue, "课程对应章节无任何任务节点，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, `[`, pointAction.Knowledge[index].Name, `] `, lg.Blue, "课程对应章节无任何任务节点，已自动跳过")
 		return
 	}
 	// 视屏类型
@@ -355,24 +355,24 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 				userCache, key, courseId, videoDTO.KnowledgeID, videoDTO.CardIndex, courseItem.Cpi)
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					break
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
 				if strings.Contains(err2.Error(), "活体检测失败") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号所录入的人脸可能并不规范，请自行拍摄人脸放到assets/face/账号名称.jpg路径下再重试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号所录入的人脸可能并不规范，请自行拍摄人脸放到assets/face/账号名称.jpg路径下再重试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 			videoDTO.AttachmentsDetection(card)
 
 			if !videoDTO.IsJob {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, `[`, pointAction.Knowledge[index].Name, `] `, lg.Blue, "该视屏或音频非任务点或已完成，已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, `[`, pointAction.Knowledge[index].Name, `] `, lg.Blue, "该视屏或音频非任务点或已完成，已自动跳过")
 				continue
 			}
 			videoDTO.Enc = enc                                        //赋值enc值
@@ -398,14 +398,14 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 				userCache, key, courseId, documentDTO.KnowledgeID, documentDTO.CardIndex, courseItem.Cpi)
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					break
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 			documentDTO.AttachmentsDetection(card)
@@ -441,30 +441,30 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					continue
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 			flag, _ := workDTO.AttachmentsDetection(mobileCard)
 			questionAction, err2 := xuexitong.ParseWorkQuestionAction(userCache, &workDTO)
 			if err2 != nil && strings.Contains(err2.Error(), "已截止，不能作答") {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Yellow, "该试卷已到截止时间，已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Yellow, "该试卷已到截止时间，已自动跳过")
 				continue
 			}
 			if !flag {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Green, "该作业已完成，已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Green, "该作业已完成，已自动跳过")
 				continue
 			}
 			if len(questionAction.Short) == 0 && len(questionAction.Choice) == 0 &&
 				len(questionAction.Judge) == 0 && len(questionAction.Fill) == 0 &&
 				len(questionAction.TermExplanation) == 0 && len(questionAction.Essay) == 0 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Yellow, "该作业任务点无题目，已自动跳过")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", questionAction.Title, "】", lg.Yellow, "该作业任务点无题目，已自动跳过")
 				continue
 			}
 			//if !strings.Contains(questionAction.Title, "2.1小节测验") {
@@ -482,14 +482,14 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					continue
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 			hyperlinkDTO.AttachmentsDetection(card)
@@ -506,14 +506,14 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					continue
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 			liveDTO.AttachmentsDetection(card)
@@ -545,14 +545,14 @@ func nodeRun(setting config.Setting, user *config.User, userCache *xuexitongApi.
 				userCache, key, courseId, bbsDTO.KnowledgeID, bbsDTO.CardIndex, courseItem.Cpi)
 			if err2 != nil {
 				if strings.Contains(err2.Error(), "章节未开放") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "该章节未开放，可能是因为前面章节有任务点未学完导致后续任务点未开放，已自动跳过该任务点")
 					return
 				}
 				if strings.Contains(err2.Error(), "没有历史人脸") {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.BoldRed, "过人脸失败，该账号可能从未进行过人脸识别，请先进行一次人脸识别后再试")
 					os.Exit(0)
 				}
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", `[`, courseItem.CourseName, `] `, lg.Red, err2.Error())
 				os.Exit(0)
 			}
 
@@ -660,14 +660,14 @@ func ExecuteVideo(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 				if strings.Contains(err.Error(), "failed to fetch video, status code: 403") { //触发403立即使用人脸检测
 					if mode == 1 {
 						mode = 0
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "检测到手机端触发403正在切换为Web端...")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "检测到手机端触发403正在切换为Web端...")
 						continue
 					}
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "触发403正在尝试绕过人脸识别...")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "触发403正在尝试绕过人脸识别...")
 					//上传人脸
 					pullJson, img, err2 := cache.GetHistoryFaceImg("")
 					if err2 != nil {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.BoldRed, "上传人脸失败，已自动跳过该视屏", pullJson, err2)
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.BoldRed, "上传人脸失败，已自动跳过该视屏", pullJson, err2)
 						return
 						//os.Exit(0)
 					}
@@ -675,9 +675,9 @@ func ExecuteVideo(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 					//uuid,qrEnc,ObjectId,successEnc
 					_, _, _, _, errPass := xuexitong.PassFacePCAction(cache, p.CourseID, p.ClassID, p.Cpi, fmt.Sprintf("%d", p.KnowledgeID), p.Enc, p.JobID, p.ObjectID, p.Mid, p.RandomCaptureTime, disturbImage)
 					if errPass != nil {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "绕过人脸失败", errPass.Error(), "请在学习通客户端上确保最近一次人脸识别是正确的，yatori会自动拉取最近一次识别的人脸数据进行")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "绕过人脸失败", errPass.Error(), "请在学习通客户端上确保最近一次人脸识别是正确的，yatori会自动拉取最近一次识别的人脸数据进行")
 					} else {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "绕过人脸成功")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "绕过人脸成功")
 					}
 					time.Sleep(5 * time.Second) //不要删！！！！一定要等待一小段时间才能请求PageMobile
 					continue
@@ -699,26 +699,26 @@ func ExecuteVideo(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			outTimeMsg := gojsonq.New().JSONString(playReport).Find("OutTimeMsg")
 			if outTimeMsg != nil {
 				if outTimeMsg.(string) == "观看时长超过阈值" {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), "观看时长超过阈值，已直接提交", lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), "观看时长超过阈值，已直接提交", lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 					break
 				}
 			}
 			if gojsonq.New().JSONString(playReport).Find("isPassed").(bool) == true && playingTime >= p.Duration { //看完了，则直接退出
 				if overTime == 0 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 				} else {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", lg.Green, "过超提交成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", lg.Green, "过超提交成功", lg.Default, " ", "观看进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 				}
 				break
 			}
 
 			if overTime == 0 { //正常提交
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
 			} else { //过超提交
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", "观看进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "观看时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", "观看进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
 			}
 			if overTime >= limitTime { //过超提交触发
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "过超提交失败，自动进行下一任务...")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "过超提交失败，自动进行下一任务...")
 				break
 			}
 
@@ -728,7 +728,7 @@ func ExecuteVideo(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			} else if p.Duration == playingTime { //记录过超提交触发条件
 				//判断是否为任务点，如果为任务点那么就不累计过超提交
 				if p.JobID == "" && p.Attachment == nil {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "该视频为非任务点看完后直接跳入下一视频")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "该视频为非任务点看完后直接跳入下一视频")
 					break
 				} else {
 					overTime += extendSec
@@ -740,7 +740,7 @@ func ExecuteVideo(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			}
 		}
 	} else {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "该视屏任务点解析失败，可能是任务点视屏本身问题，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "该视屏任务点解析失败，可能是任务点视屏本身问题，已自动跳过")
 		//log.Fatal("视频解析失败")
 	}
 }
@@ -785,14 +785,14 @@ func ExecuteAudio(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 				if strings.Contains(err.Error(), "failed to fetch video, status code: 403") { //触发403立即使用人脸检测
 					if mode == 1 {
 						mode = 0
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "检测到手机端触发403正在切换为Web端...")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "检测到手机端触发403正在切换为Web端...")
 						continue
 					}
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "触发403正在尝试绕过人脸识别...")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "触发403正在尝试绕过人脸识别...")
 					//上传人脸
 					pullJson, img, err2 := cache.GetHistoryFaceImg("")
 					if err2 != nil {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.BoldRed, "上传人脸失败，已自动跳过该音频", pullJson, err2)
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.BoldRed, "上传人脸失败，已自动跳过该音频", pullJson, err2)
 						return
 						//os.Exit(0)
 					}
@@ -800,9 +800,9 @@ func ExecuteAudio(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 					//uuid,qrEnc,ObjectId,successEnc
 					_, _, _, _, errPass := xuexitong.PassFacePCAction(cache, p.CourseID, p.ClassID, p.Cpi, fmt.Sprintf("%d", p.KnowledgeID), p.Enc, p.JobID, p.ObjectID, p.Mid, p.RandomCaptureTime, disturbImage)
 					if errPass != nil {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "绕过人脸失败", errPass.Error(), "请在学习通客户端上确保最近一次人脸识别是正确的，yatori会自动拉取最近一次识别的人脸数据进行")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "绕过人脸失败", errPass.Error(), "请在学习通客户端上确保最近一次人脸识别是正确的，yatori会自动拉取最近一次识别的人脸数据进行")
 					} else {
-						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "绕过人脸成功")
+						lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "绕过人脸成功")
 					}
 					time.Sleep(5 * time.Second) //不要删！！！！一定要等待一小段时间才能请求PageMobile
 					continue
@@ -824,26 +824,26 @@ func ExecuteAudio(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			outTimeMsg := gojsonq.New().JSONString(playReport).Find("OutTimeMsg")
 			if outTimeMsg != nil {
 				if outTimeMsg.(string) == "观看时长超过阈值" {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), "音频提交时长超过阈值，已直接提交", lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), "音频提交时长超过阈值，已直接提交", lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 					break
 				}
 			}
 			if gojsonq.New().JSONString(playReport).Find("isPassed").(bool) == true && playingTime >= p.Duration { //看完了，则直接退出
 				if overTime == 0 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 				} else {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", lg.Green, "过超提交成功", lg.Default, " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(p.Duration)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", lg.Green, "过超提交成功", lg.Default, " ", "听音进度：", fmt.Sprintf("%.2f", float32(p.Duration)/float32(p.Duration)*100), "%")
 				}
 				break
 			}
 
 			if overTime == 0 { //正常提交
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "听音进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
 			} else { //过超提交
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", "听音进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "听音时间：", strconv.Itoa(playingTime)+"/"+strconv.Itoa(p.Duration), " ", "过超时间：", strconv.Itoa(overTime)+"/"+strconv.Itoa(limitTime), " ", "听音进度：", fmt.Sprintf("%.2f", float32(playingTime)/float32(p.Duration)*100), "%")
 			}
 			if overTime >= limitTime { //过超提交触发
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "过超提交失败，自动进行下一任务...")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "过超提交失败，自动进行下一任务...")
 				break
 			}
 
@@ -853,7 +853,7 @@ func ExecuteAudio(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			} else if p.Duration == playingTime { //记录过超提交触发条件
 				//判断是否为任务点，如果为任务点那么就不累计过超提交
 				if p.JobID == "" && p.Attachment == nil {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "该音频为非任务点看完后直接跳入下一任务点")
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "提交状态：", lg.Green, strconv.FormatBool(gojsonq.New().JSONString(playReport).Find("isPassed").(bool)), lg.Default, " ", "该音频为非任务点看完后直接跳入下一任务点")
 					break
 				} else {
 					overTime += extendSec
@@ -865,7 +865,7 @@ func ExecuteAudio(user *config.User, cache *xuexitongApi.XueXiTUserCache, course
 			}
 		}
 	} else {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "该音频任务点解析失败，可能是任务点音频本身问题，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Red, "该音频任务点解析失败，可能是任务点音频本身问题，已自动跳过")
 		//log.Fatal("视频解析失败")
 	}
 }
@@ -884,7 +884,7 @@ func ExecuteDocument(user *config.User, cache *xuexitongApi.XueXiTUserCache, cou
 	}
 
 	if gojsonq.New().JSONString(report).Find("status").(bool) {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "文档阅览状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(report).Find("status").(bool)), lg.Default, " ")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "文档阅览状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(report).Find("status").(bool)), lg.Default, " ")
 	}
 }
 
@@ -900,7 +900,7 @@ func ExecuteHyperlink(user *config.User, cache *xuexitongApi.XueXiTUserCache, co
 	}
 
 	if gojsonq.New().JSONString(report).Find("status").(bool) {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "外链任务点状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(report).Find("status").(bool)), lg.Default, " ")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "外链任务点状态：", lg.Green, lg.Green, strconv.FormatBool(gojsonq.New().JSONString(report).Find("status").(bool)), lg.Default, " ")
 	}
 }
 
@@ -911,7 +911,7 @@ func ExecuteLive(user *config.User, cache *xuexitongApi.XueXiTUserCache, courseI
 
 	//如果该直播还未开播
 	if p.LiveStatusCode == 0 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "该直播任务点还未开播，已自动跳过")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Yellow, "该直播任务点还未开播，已自动跳过")
 		return
 	}
 	relationReport, err2 := point.LiveCreateRelationAction(cache, p)
@@ -930,7 +930,7 @@ func ExecuteLive(user *config.User, cache *xuexitongApi.XueXiTUserCache, courseI
 		}
 
 		if strings.Contains(report, "@success") {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "直播任务点状态：", lg.Green, report, lg.Default, "，直播观看进度：", lg.Green, fmt.Sprintf("%.2f", p.VideoCompletePercent), "%")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", "直播任务点状态：", lg.Green, report, lg.Default, "，直播观看进度：", lg.Green, fmt.Sprintf("%.2f", p.VideoCompletePercent), "%")
 		} else {
 			if err != nil {
 				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), `[`, cache.Name, `] `, "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】", lg.BoldRed, "直播任务点学习提交接口访问异常，返回信息：", report, err.Error())
@@ -939,7 +939,7 @@ func ExecuteLive(user *config.User, cache *xuexitongApi.XueXiTUserCache, courseI
 			}
 		}
 		if p.VideoCompletePercent >= passValue {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "直播任务点已完成")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", p.Title, "】 >>> ", lg.Green, "直播任务点已完成")
 			return
 		}
 		time.Sleep(30 * time.Second)
@@ -971,7 +971,7 @@ func ExecuteBBS(user *config.User, cache *xuexitongApi.XueXiTUserCache, setting 
 	if err != nil {
 		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), `[`, cache.Name, `] `, "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", bbsTopic.Title, "】", lg.BoldRed, "讨论任务点学习提交接口访问异常，返回信息：", report, err.Error())
 	} else {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", bbsTopic.Title, "】 >>> ", "讨论任务点状态：", lg.Green, lg.Green, gojsonq.New().JSONString(report).Find("msg").(string))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", bbsTopic.Title, "】 >>> ", "讨论任务点状态：", lg.Green, lg.Green, gojsonq.New().JSONString(report).Find("msg").(string))
 	}
 
 }
@@ -979,11 +979,11 @@ func ExecuteBBS(user *config.User, cache *xuexitongApi.XueXiTUserCache, setting 
 // 章测处理逻辑
 func chapterTestAction(userCache *xuexitongApi.XueXiTUserCache, user *config.User, setting config.Setting, courseItem *xuexitong.XueXiTCourse, knowledgeItem xuexitong.KnowledgeItem, questionAction xuexitongApi.Question) {
 	if user.CoursesCustom.AutoExam == 1 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在AI自动写章节作业...")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在AI自动写章节作业...")
 	} else if user.CoursesCustom.AutoExam == 2 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在外挂题库自动写章节作业...")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在外挂题库自动写章节作业...")
 	} else if user.CoursesCustom.AutoExam == 3 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在内置AI自动写章节作业...")
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", lg.Default, "【"+courseItem.CourseName+"】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Yellow, "正在内置AI自动写章节作业...")
 	}
 	stopStart := 1
 	stopEnd := 2
@@ -1149,11 +1149,11 @@ func chapterTestAction(userCache *xuexitongApi.XueXiTUserCache, user *config.Use
 			//如果提交失败那么直接输出AI答题的文本
 			if gojsonq.New().JSONString(resultStr).Find("status") == false {
 				if user.CoursesCustom.AutoExam == 1 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
 				} else if user.CoursesCustom.AutoExam == 2 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "外挂题库答题保存失败,返回信息："+resultStr, " 外挂题库答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "外挂题库答题保存失败,返回信息："+resultStr, " 外挂题库答题信息：", questionAction.String())
 				} else if user.CoursesCustom.AutoExam == 3 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", "学习通内置AI"), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", "学习通内置AI"), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
 				}
 
 			}
@@ -1162,11 +1162,11 @@ func chapterTestAction(userCache *xuexitongApi.XueXiTUserCache, user *config.Use
 			resultStr, _ = xuexitong.WorkNewSubmitAnswerAction(userCache, questionAction, true) //没有留空则提交
 			if gojsonq.New().JSONString(resultStr).Find("status") == false {
 				if user.CoursesCustom.AutoExam == 1 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
 				} else if user.CoursesCustom.AutoExam == 2 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "外挂题库答题保存失败,返回信息："+resultStr, " 外挂题库答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "外挂题库答题保存失败,返回信息："+resultStr, " 外挂题库答题信息：", questionAction.String())
 				} else if user.CoursesCustom.AutoExam == 3 {
-					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", "学习通内置AI"), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
+					lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", "学习通内置AI"), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.BoldRed, "AI答题保存失败,返回信息："+resultStr, " AI答题信息：", questionAction.String())
 				}
 			}
 		}
@@ -1174,74 +1174,74 @@ func chapterTestAction(userCache *xuexitongApi.XueXiTUserCache, user *config.Use
 	//提交试卷成功的话{"msg":"success!","stuStatus":4,"backUrl":"","url":"/mooc-ans/api/work?courseid=250215285&workId=b63d4e7466624ace9c382cd112c9c95a&clazzId=125521307&knowledgeid=951783044&ut=s&type=&submit=true&jobid=work-6967802218b44f4dace8e3a8755cf3d9&enc=db5c2413ac1367c5ed28b4cfa5194318&ktoken=c0bf3b45e0b3e625e377cae3b77e1cfa&mooc2=0&skipHeader=true&originJobId=null","status":true}
 	//提交作业失败的话{"msg" : "作业提交失败！","status" : false}
 	if user.CoursesCustom.AutoExam == 1 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业AI答题完毕,服务器返回信息：", resultStr)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业AI答题完毕,服务器返回信息：", resultStr)
 	} else if user.CoursesCustom.AutoExam == 2 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业外挂题库答题完毕,服务器返回信息：", resultStr)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业外挂题库答题完毕,服务器返回信息：", resultStr)
 	} else if user.CoursesCustom.AutoExam == 3 {
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业内置AI答题完毕,服务器返回信息：", resultStr)
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", knowledgeItem.Label, " ", knowledgeItem.Name, "】", "【", questionAction.Title, "】", lg.Green, "章节作业内置AI答题完毕,服务器返回信息：", resultStr)
 	}
 
 }
 
 // 作业处理逻辑
 func workAction(userCache *xuexitongApi.XueXiTUserCache, user *config.User, setting config.Setting, courseItem *xuexitong.XueXiTCourse, work xuexitong.XXTWork) {
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Yellow, "正在写作业中...")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Yellow, "正在写作业中...")
 	//拉取题目
 	for i := range work.QuestionTotal {
 		question, err2 := work.PullWorkQuestionAction(userCache, i)
 		if err2 != nil {
 			log.Fatal(err2)
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Yellow, fmt.Sprintf("写作业状态中,正在回答第%d题", i+1))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Yellow, fmt.Sprintf("写作业状态中,正在回答第%d题", i+1))
 		//内置AI自动写题
 		if user.CoursesCustom.AutoExam == 1 {
 			err3 := question.WriteQuestionForAIAction(userCache, setting.AiSetting.AiUrl, setting.AiSetting.Model, setting.AiSetting.AiType, setting.AiSetting.APIKEY)
 			if err3 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "AI回答错误:", err3.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "AI回答错误:", err3.Error())
 			}
 		} else if user.CoursesCustom.AutoExam == 2 {
 			question.WriteQuestionForExternalAction(setting.ApiQueSetting.Url)
 		} else if user.CoursesCustom.AutoExam == 3 {
 			err3 := question.WriteQuestionForXXTAIAction(userCache, question.ClassId, question.CourseId, question.Cpi)
 			if err3 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "内置AI回答错误:", err3.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "内置AI回答错误:", err3.Error())
 			}
 		}
 		//提交写的题
 		submitResult, err3 := question.SubmitWorkAnswerAction(userCache, (user.CoursesCustom.ExamAutoSubmit == 1 || user.CoursesCustom.ExamAutoSubmit == 2) && work.QuestionTotal == i+1)
 		if err3 != nil {
 			//log.Fatal(err3)
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "作业提交失败:", err3.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Red, "作业提交失败:", err3.Error())
 		}
 
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Green, fmt.Sprintf("第%d题回答成功,服务器返回:%s", i+1, submitResult))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Green, fmt.Sprintf("第%d题回答成功,服务器返回:%s", i+1, submitResult))
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Green, "作业已完成")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", work.Name, "】", lg.Green, "作业已完成")
 
 }
 
 // 考试处理逻辑
 func examAction(userCache *xuexitongApi.XueXiTUserCache, user *config.User, setting config.Setting, courseItem *xuexitong.XueXiTCourse, exam xuexitong.XXTExam) {
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, "正在考试中...")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, "正在考试中...")
 	//拉取题目
 	for i := range exam.QuestionTotal {
 		question, err2 := exam.PullExamQuestionAction(userCache, i)
 		if err2 != nil {
 			log.Fatal(err2)
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, fmt.Sprintf("考试状态中,正在回答第%d题,总共%d题", i+1, exam.QuestionTotal))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Yellow, fmt.Sprintf("考试状态中,正在回答第%d题,总共%d题", i+1, exam.QuestionTotal))
 		//内置AI自动写题
 		if user.CoursesCustom.AutoExam == 1 {
 			err3 := question.WriteQuestionForAIAction(userCache, setting.AiSetting.AiUrl, setting.AiSetting.Model, setting.AiSetting.AiType, setting.AiSetting.APIKEY)
 			if err3 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "AI回答错误:", err3.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "AI回答错误:", err3.Error())
 			}
 		} else if user.CoursesCustom.AutoExam == 2 {
 			question.WriteQuestionForExternalAction(setting.ApiQueSetting.Url)
 		} else if user.CoursesCustom.AutoExam == 3 {
 			err3 := question.WriteQuestionForXXTAIAction(userCache, question.ClassId, question.CourseId, question.Cpi)
 			if err3 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "内置AI回答错误:", err3.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "内置AI回答错误:", err3.Error())
 			}
 		}
 		//提交写的题
@@ -1252,24 +1252,24 @@ func examAction(userCache *xuexitongApi.XueXiTUserCache, user *config.User, sett
 		submitResult, err3 := question.SubmitExamAnswerAction(userCache, isSubmit)
 		if err3 != nil {
 			//log.Fatal(err3)
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "试卷提交失败:", err3.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "试卷提交失败:", err3.Error())
 		}
 		//处理限制提交时间的考试-----------------
 		re := regexp.MustCompile(`考试(\d+)分钟内不允许提交考试`)
 		matches := re.FindStringSubmatch(submitResult)
 		if len(matches) > 1 {
 			minSubmitTime, _ := strconv.Atoi(matches[1])
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, fmt.Sprintf("检测到该考试限制开考%d分钟内不允许提交考试，已自动延时%d分钟...", minSubmitTime, minSubmitTime))
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, fmt.Sprintf("检测到该考试限制开考%d分钟内不允许提交考试，已自动延时%d分钟...", minSubmitTime, minSubmitTime))
 			time.Sleep(time.Duration(minSubmitTime) * time.Minute)
 			submitResult, err3 = question.SubmitExamAnswerAction(userCache, isSubmit)
 		}
 
 		//如果考试时间已用完则直接退出
 		if strings.Contains(submitResult, "考试时间已用完,不允许提交答案!") {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "试卷提交失败，考试时间已用完，已自动跳过。服务器返回信息:", submitResult)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Red, "试卷提交失败，考试时间已用完，已自动跳过。服务器返回信息:", submitResult)
 			break
 		}
-		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, fmt.Sprintf("第%d题回答成功,服务器返回:%s", i+1, submitResult))
+		lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, fmt.Sprintf("第%d题回答成功,服务器返回:%s", i+1, submitResult))
 	}
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Name, lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, "考试已完成")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Name), lg.Default, "] ", "【", courseItem.CourseName, "】", "【", exam.Name, "】", lg.Green, "考试已完成")
 }

--- a/logic/yinghua/YinghuaPart.go
+++ b/logic/yinghua/YinghuaPart.go
@@ -69,7 +69,7 @@ func UserLoginOperation(users []config.User) []*yinghuaApi.YingHuaUserCache {
 			go ipProxy(user, cache)                   // 携程定时变换代理地址
 			err1 := yinghua.YingHuaLoginAction(cache) // 登录
 			if err1 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.White, "] ", lg.Red, err1.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.White, "] ", lg.Red, err1.Error())
 				log.Fatal(err1) //登录失败则直接退出
 			}
 			go keepAliveLogin(cache) //携程保活
@@ -85,7 +85,7 @@ var soundMut sync.Mutex
 
 func userBlock(setting config.Setting, user *config.User, cache *yinghuaApi.YingHuaUserCache) {
 	list, _ := yinghua.CourseListAction(cache) //拉取课程列表
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "正在定位上次学习位置...")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "正在定位上次学习位置...")
 	var nodesLock sync.WaitGroup //节点锁
 	for _, item := range list {  //遍历所有待刷视频
 		nodesLock.Add(1)
@@ -95,7 +95,7 @@ func userBlock(setting config.Setting, user *config.User, cache *yinghuaApi.Ying
 			//如果是暴力模式，等结束后再进行一次去红模式
 			if user.CoursesCustom.VideoModel == 2 {
 
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, user.Account, lg.Default, "] ", lg.Yellow, "暴力模式执行完毕，正在自动执行去红模式...")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(user.Account), lg.Default, "] ", lg.Yellow, "暴力模式执行完毕，正在自动执行去红模式...")
 				resUser := *user                               //改为去红模式
 				resUser.CoursesCustom.VideoModel = 3           //标记为去红模式并启动
 				nodeListStudy(setting, &resUser, cache, &item) //递归执行去红模式
@@ -105,7 +105,7 @@ func userBlock(setting config.Setting, user *config.User, cache *yinghuaApi.Ying
 		}()
 	}
 	nodesLock.Wait() //等待所有节点结束
-	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, cache.Account, lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
+	lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(cache.Account), lg.Default, "] ", lg.Purple, "所有待学习课程学习完毕")
 
 	//如果开启了邮箱通知
 	if setting.EmailInform.Sw == 1 && len(user.InformEmails) > 0 {
@@ -126,7 +126,7 @@ func keepAliveLogin(UserCache *yinghuaApi.YingHuaUserCache) {
 		select {
 		case <-ticker.C:
 			api := yinghuaApi.KeepAliveApi(*UserCache, 8)
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr["YINGHUA"]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.DarkGray, "登录心跳保活状态：", api)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr["YINGHUA"]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.DarkGray, "登录心跳保活状态：", api)
 		}
 	}
 }
@@ -142,18 +142,18 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *yinghua
 	if len(user.CoursesCustom.IncludeCourses) != 0 && !config.CmpCourse(course.Name, user.CoursesCustom.IncludeCourses) {
 		return
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "正在学习课程：", lg.Yellow, " 【"+course.Name+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "正在学习课程：", lg.Yellow, " 【"+course.Name+"】 ")
 
 	//如果课程时间未到开课时间则直接return
 	//{"_code":9,"status":false,"msg":"课程还未开始!","result":{}}
 	if time2.Now().Before(course.StartDate) {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", " 【", course.Name, "】 >>> ", lg.Red, "该课程还未开始已自动跳过")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", " 【", course.Name, "】 >>> ", lg.Red, "该课程还未开始已自动跳过")
 		return
 	}
 	//执行刷课---------------------------------
 	nodeList, err := yinghua.VideosListAction(userCache, *course) //拉取对应课程的视频列表
 	if err != nil {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", " 【", course.Name, "】 >>> ", lg.Red, "拉取视屏列表失败", err.Error())
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", " 【", course.Name, "】 >>> ", lg.Red, "拉取视屏列表失败", err.Error())
 	}
 	var videosLock sync.WaitGroup //视频节点锁
 	// 提交学时
@@ -186,10 +186,10 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *yinghua
 		if setting.BasicSetting.LogModel == 1 {
 			action, err := yinghua.CourseDetailAction(userCache, course.Id)
 			if err != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Default, " 【"+course.Name+"】 ", lg.Red, "拉取课程进度失败", err.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Default, " 【"+course.Name+"】 ", lg.Red, "拉取课程进度失败", err.Error())
 				break
 			}
-			modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Default, " 【"+course.Name+"】 ", "视频学习进度：", strconv.Itoa(action.VideoLearned), "/", strconv.Itoa(action.VideoCount), " ", "课程总学习进度：", fmt.Sprintf("%.2f", action.Progress*100), "%")
+			modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Default, " 【"+course.Name+"】 ", "视频学习进度：", strconv.Itoa(action.VideoLearned), "/", strconv.Itoa(action.VideoCount), " ", "课程总学习进度：", fmt.Sprintf("%.2f", action.Progress*100), "%")
 		}
 	}
 	//如果还有标红的则再运行一遍
@@ -198,7 +198,7 @@ func nodeListStudy(setting config.Setting, user *config.User, userCache *yinghua
 		return
 	}
 	videosLock.Wait() //等待所有视频刷完
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Green, "课程", " 【"+course.Name+"】 ", "学习完毕")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 1, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Green, "课程", " 【"+course.Name+"】 ", "学习完毕")
 }
 
 // videoAction 刷视频逻辑抽离
@@ -209,13 +209,13 @@ func videoAction(setting config.Setting, user *config.User, UserCache *yinghuaAp
 	if int(node.Progress) == 100 { //过滤看完了的视屏
 		return
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】")
 	time := node.ViewedDuration //设置当前观看时间为最后看视频的时间
 	studyId := "0"              //服务器端分配的学习ID
 	for {
 		time += 5
 		if node.Progress == 100 {
-			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", " ", lg.Blue, "学习完毕")
+			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", " ", lg.Blue, "学习完毕")
 			break //如果看完了，也就是进度为100那么直接跳过
 		}
 		//提交学时
@@ -230,16 +230,16 @@ func videoAction(setting config.Setting, user *config.User, UserCache *yinghuaAp
 		msgVal := gojsonq.New().JSONString(sub).Find("msg")
 		msg, ok := msgVal.(string)
 		if !ok || msg == "" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Red, "提交状态异常，msg 字段为空或格式错误", sub)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Red, "提交状态异常，msg 字段为空或格式错误", sub)
 			time2.Sleep(10 * time2.Second)
 			continue
 		}
 		if msg != "提交学时成功!" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
 			//{"_code":9,"status":false,"msg":"该课程解锁时间【2024-11-14 12:00:00】未到!","result":{}}，如果未到解锁时间则跳过
 			reg1 := regexp.MustCompile(`该课程解锁时间【[^【]*】未到!`)
 			if reg1.MatchString(msg) {
-				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
+				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
 				break
 			}
 			time2.Sleep(10 * time2.Second)
@@ -250,7 +250,7 @@ func videoAction(setting config.Setting, user *config.User, UserCache *yinghuaAp
 		if idFloat, ok := studyIdVal.(float64); ok {
 			studyId = strconv.Itoa(int(idFloat))
 		}
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
 		time2.Sleep(5 * time2.Second)
 		if time >= node.VideoDuration {
 			break //如果看完该视频则直接下一个
@@ -270,13 +270,13 @@ func videoVioLenceAction(setting config.Setting, user *config.User, UserCache *y
 	if int(node.Progress) == 100 { //过滤看完了的视屏
 		return
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在学习视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ")
 	time := node.ViewedDuration //设置当前观看时间为最后看视频的时间
 	studyId := "0"              //服务器端分配的学习ID
 	for {
 		time += 5
 		if node.Progress == 100 {
-			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", " ", lg.Blue, "学习完毕")
+			modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", " ", lg.Blue, "学习完毕")
 			break //如果看完了，也就是进度为100那么直接跳过
 		}
 		//提交学时
@@ -291,17 +291,17 @@ func videoVioLenceAction(setting config.Setting, user *config.User, UserCache *y
 		msgVal := gojsonq.New().JSONString(sub).Find("msg")
 		msg, ok := msgVal.(string)
 		if !ok || msg == "" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Red, "提交状态异常，msg 字段为空或格式错误")
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Red, "提交状态异常，msg 字段为空或格式错误")
 			time2.Sleep(10 * time2.Second)
 			continue
 		}
 
 		if msg != "提交学时成功!" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
 
 			reg1 := regexp.MustCompile(`该课程解锁时间【[^【]*】未到!`)
 			if reg1.MatchString(msg) {
-				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
+				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
 				break
 			}
 			time2.Sleep(10 * time2.Second)
@@ -309,7 +309,7 @@ func videoVioLenceAction(setting config.Setting, user *config.User, UserCache *y
 		}
 		//打印日志部分
 		studyId = strconv.Itoa(int(gojsonq.New().JSONString(sub).Find("result.data.studyId").(float64)))
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
 
 		time2.Sleep(5 * time2.Second)
 		if time >= node.VideoDuration {
@@ -327,7 +327,7 @@ func videoBadRedAction(setting config.Setting, user *config.User, UserCache *yin
 	if node.ErrorMessage != "检测到可能使用并行播放刷课" {
 		return
 	}
-	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", lg.Yellow, "正在消红视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ")
+	modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", lg.Yellow, "正在消红视频：", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ")
 	time := node.ViewedDuration //设置当前观看时间为最后看视频的时间
 
 	studyId := "0" //服务器端分配的学习ID
@@ -344,16 +344,16 @@ func videoBadRedAction(setting config.Setting, user *config.User, UserCache *yin
 		msgVal := gojsonq.New().JSONString(sub).Find("msg")
 		msg, ok := msgVal.(string)
 		if !ok || msg == "" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.Red, "提交状态异常，msg 字段为空或格式错误", sub)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.Red, "提交状态异常，msg 字段为空或格式错误", sub)
 			time2.Sleep(10 * time2.Second)
 			continue
 		}
 		if msg != "提交学时成功!" {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", "提交状态：", lg.Red, sub)
 			//{"_code":9,"status":false,"msg":"该课程解锁时间【2024-11-14 12:00:00】未到!","result":{}}，如果未到解锁时间则跳过
 			reg1 := regexp.MustCompile(`该课程解锁时间【[^【]*】未到!`)
 			if reg1.MatchString(msg) {
-				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
+				modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, "该课程未到解锁时间已自动跳过")
 				break
 			}
 			time2.Sleep(10 * time2.Second)
@@ -364,7 +364,7 @@ func videoBadRedAction(setting config.Setting, user *config.User, UserCache *yin
 		if idFloat, ok := studyIdVal.(float64); ok {
 			studyId = strconv.Itoa(int(idFloat))
 		}
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, UserCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, " 去红模式 ", lg.Default, "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(UserCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 >>> ", lg.Red, " 去红模式 ", lg.Default, "提交状态：", lg.Green, msg, lg.Default, " ", "观看时间：", strconv.Itoa(time)+"/"+strconv.Itoa(node.VideoDuration), " ", "观看进度：", fmt.Sprintf("%.2f", float32(time)/float32(node.VideoDuration)*100), "%")
 		time2.Sleep(8 * time2.Second) //隔8s下一个去红
 		break                         //因为是去红模式，所以直接退出
 	}
@@ -401,9 +401,9 @@ func workAction(setting config.Setting, user *config.User, userCache *yinghuaApi
 		return
 	}
 	if user.CoursesCustom.AutoExam == 1 {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在AI自动写章节作业...")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在AI自动写章节作业...")
 	} else if user.CoursesCustom.AutoExam == 2 {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在外置题库自动写章节作业...")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在外置题库自动写章节作业...")
 	}
 
 	//开始写作业
@@ -419,27 +419,27 @@ func workAction(setting config.Setting, user *config.User, userCache *yinghuaApi
 		}
 
 		if err != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, "该章节作业无法正常执行，服务器返回信息：", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, "该章节作业无法正常执行，服务器返回信息：", err.Error())
 			continue
 		}
 		if user.CoursesCustom.ExamAutoSubmit == 1 {
 			//打印最终分数
 			s, err1 := yinghua.WorkedFinallyScoreAction(userCache, work)
 			if err1 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, err1)
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, err1)
 				continue
 			}
 			if user.CoursesCustom.AutoExam == 1 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "章节作业AI答题完毕，最高分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", work.Score))
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "章节作业AI答题完毕，最高分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", work.Score))
 			} else if user.CoursesCustom.AutoExam == 2 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", " 【", node.Name, "】", lg.Green, "章节作业外置题库答题完毕，最高分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", work.Score))
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", " 【", node.Name, "】", lg.Green, "章节作业外置题库答题完毕，最高分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", work.Score))
 			}
 
 		} else {
 			if user.CoursesCustom.AutoExam == 1 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,请自行前往主页提交试卷")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,请自行前往主页提交试卷")
 			} else if user.CoursesCustom.AutoExam == 2 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,请自行前往主页提交试卷")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,请自行前往主页提交试卷")
 			}
 		}
 	}
@@ -480,9 +480,9 @@ func examAction(setting config.Setting, user *config.User, userCache *yinghuaApi
 	}
 	//开始考试
 	if user.CoursesCustom.AutoExam == 1 {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在AI自动考试...")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在AI自动考试...")
 	} else if user.CoursesCustom.AutoExam == 2 {
-		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在外置题库自动考试...")
+		modelLog.ModelPrint(setting.BasicSetting.LogModel == 0, lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "<"+setting.AiSetting.AiType+">", lg.Default, fmt.Sprintf("【%s】", course.Name), "【"+node.Name+"】 ", lg.Yellow, "正在外置题库自动考试...")
 	}
 
 	for _, exam := range detailAction {
@@ -497,7 +497,7 @@ func examAction(setting config.Setting, user *config.User, userCache *yinghuaApi
 			break
 		}
 		if err != nil {
-			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, "该考试无法正常执行，服务器返回信息：", err.Error())
+			lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, "该考试无法正常执行，服务器返回信息：", err.Error())
 			continue
 		}
 
@@ -505,19 +505,19 @@ func examAction(setting config.Setting, user *config.User, userCache *yinghuaApi
 			//打印最终分数
 			s, err1 := yinghua.ExamFinallyScoreAction(userCache, exam)
 			if err1 != nil {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", "<"+setting.AiSetting.AiType+">", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, err1.Error())
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", "<"+setting.AiSetting.AiType+">", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】 ", lg.BoldRed, err1.Error())
 				continue
 			}
 			if user.CoursesCustom.AutoExam == 1 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,最终分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", exam.Score))
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,最终分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", exam.Score))
 			} else if user.CoursesCustom.AutoExam == 2 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,最终分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", exam.Score))
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,最终分：", s, "分", " 试卷总分：", fmt.Sprintf("%.2f分", exam.Score))
 			}
 		} else {
 			if user.CoursesCustom.AutoExam == 1 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,请自行前往主页提交试卷")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("<%s>", setting.AiSetting.AiType), fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "AI考试完毕,请自行前往主页提交试卷")
 			} else if user.CoursesCustom.AutoExam == 2 {
-				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, userCache.Account, lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,请自行前往主页提交试卷")
+				lg.Print(lg.INFO, fmt.Sprintf("[%s]", global.AccountTypeStr[user.AccountType]), "[", lg.Green, config.DisplayAccount(userCache.Account), lg.Default, "] ", fmt.Sprintf("【%s】", course.Name), "【", node.Name, "】", lg.Green, "外置题库考试完毕,请自行前往主页提交试卷")
 			}
 
 		}


### PR DESCRIPTION
此 PR 是 #65 的完善，感觉既然都有一个 `remarkName` 备注名字段了那干脆直接写进控制台得了，改动范围不大

### 主要更改包括：

- 若配置文件中已写备注名，则在启动时将替换原控制台输出手机号的部分；若未配置备注名则不生效

配置文件生成器部分已在 [yatori-config-generate #1](https://github.com/yatori-dev/yatori-config-generate/pull/1) 有过合并的 PR 更改