### PR TITLE
fix: 修复 Web 端启停刷课接口生命周期

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -14,8 +14,10 @@ func (router Group) ApiV1Router() {
 	router.POST("/v1/accountLoginCheck", userApi.AccountLoginCheckController)         //账号登录检测，用于检测账号密码是否正确
 	router.GET("/v1/getAccountInformForUid/:uid", userApi.GetAccountInformController) //拉取配置数据
 	router.GET("/v1/getAccountCourseList/:uid", userApi.AccountCourseListController)  //获取课程列表
-	router.GET("/v1/startBrush/:uid", userApi.StartBrushController)                   //启动刷课
-	router.GET("/v1/stopBrush/:uid", userApi.StopBrushController)                     //停止刷课
+	router.POST("/v1/startBrush/:uid", userApi.StartBrushController)                  //启动刷课
+	router.POST("/v1/stopBrush/:uid", userApi.StopBrushController)                    //停止刷课
+	router.GET("/v1/startBrush/:uid", userApi.StartBrushController)                   //启动刷课（兼容旧调用）
+	router.GET("/v1/stopBrush/:uid", userApi.StopBrushController)                     //停止刷课（兼容旧调用）
 
 	router.GET("/v1/streamLog/:id", userApi.StreamLog) //推送日志
 }

--- a/web/service/UserService.go
+++ b/web/service/UserService.go
@@ -360,18 +360,52 @@ func StartBrushService(c *gin.Context) {
 		})
 		return
 	}
-	userActivity := global.GetUserActivity(*user)
-	if userActivity != nil {
-		//userActivity.IsRunning = false
+	if user == nil {
+		c.JSON(http.StatusOK, vo.Response{
+			Code:    400,
+			Message: "该账号不存在",
+		})
+		return
 	}
-	go func() {
-		// 调用Start方法
-		(*userActivity).Start()
-	}()
 
-	c.JSON(200, gin.H{
-		"code": 200,
-		"msg":  "启动成功",
+	userActivity := global.GetUserActivity(*user)
+	activityCreated := false
+	if userActivity == nil || *userActivity == nil {
+		createActivity := activity.BuildUserActivity(*user)
+		if createActivity == nil {
+			c.JSON(http.StatusOK, vo.Response{
+				Code:    400,
+				Message: "当前平台暂不支持Web启动",
+			})
+			return
+		}
+		userActivity = &createActivity
+		activityCreated = true
+	}
+
+	if xxt, ok := (*userActivity).(*activity.XXTActivity); ok && xxt.GetUserCache() == nil {
+		if err := xxt.Login(); err != nil {
+			c.JSON(http.StatusOK, vo.Response{
+				Code:    400,
+				Message: "登录失败: " + err.Error(),
+			})
+			return
+		}
+	}
+
+	if activityCreated {
+		global.PutUserActivity(*user, userActivity)
+	}
+
+	go func(userActivity *activity.Activity) {
+		if err := (*userActivity).Start(); err != nil {
+			fmt.Println("启动失败:", err)
+		}
+	}(userActivity)
+
+	c.JSON(http.StatusOK, vo.Response{
+		Code:    200,
+		Message: "启动成功",
 	})
 }
 
@@ -382,24 +416,37 @@ func StopBrushService(c *gin.Context) {
 		Uid: uid,
 	})
 	if err != nil {
-		c.JSON(400, gin.H{})
-	}
-	if user == nil {
-		c.JSON(400, gin.H{})
+		c.JSON(http.StatusOK, vo.Response{
+			Code:    400,
+			Message: err.Error(),
+		})
 		return
 	}
+	if user == nil {
+		c.JSON(http.StatusOK, vo.Response{
+			Code:    400,
+			Message: "该账号不存在",
+		})
+		return
+	}
+
 	userActivity := global.GetUserActivity(*user)
-	if userActivity == nil {
-		c.JSON(400, gin.H{})
+	if userActivity == nil || *userActivity == nil {
+		c.JSON(http.StatusOK, vo.Response{
+			Code:    400,
+			Message: "任务未启动",
+		})
+		return
 	}
-	// 根据账号类型断言为具体活动类型并设置IsRunning
-	if xxt, ok := (*userActivity).(*activity.XXTActivity); ok {
-		xxt.IsRunning = false
-	} else if yinghua, ok := (*userActivity).(*activity.YingHuaActivity); ok {
-		yinghua.IsRunning = true
+
+	if err := (*userActivity).Stop(); err != nil {
+		c.JSON(http.StatusOK, vo.Response{
+			Code:    500,
+			Message: "停止失败: " + err.Error(),
+		})
+		return
 	}
-	(*userActivity).Stop()
-	//userActivity.Kill()
+
 	c.JSON(http.StatusOK, vo.Response{
 		Code:    200,
 		Message: "停止成功",


### PR DESCRIPTION
## 背景

Web 端启停刷课接口实际是废的：前端 `frontend/api/accountApi.ts` 一直用 POST 调用 `/v1/startBrush/:uid` 和 `/v1/stopBrush/:uid`，但后端 router 只注册了 GET，前端调用会 404。同时 `StopBrushService` 里 yinghua 分支有个明显笔误把 `IsRunning` 设成了 `true`（应该是 `false`），且绕过了 Activity 接口的 `Stop()` 生命周期。

## 修改内容

### `web/router.go`
- 给 `/v1/startBrush/:uid` 和 `/v1/stopBrush/:uid` 增加 `POST` 方法，与前端 `apiClient.post()` 调用对齐
- 保留原有 GET 路由，兼容可能的旧客户端

### `web/service/UserService.go`

**`StartBrushService`**
- 补全 `user == nil` 校验
- 当 `userActivity` 不存在时按需 `BuildUserActivity` 并写入全局 cache，避免对 nil 解引用 panic
- 只对 `XXTActivity` 且 cache 为空时自动 `Login()`（YingHua 的 `Login()` 会 `log.Fatal`，不能在 web 接口里直接触发）
- 统一返回 `vo.Response{Code, Message}` 格式（原代码部分分支返回 `gin.H{}` 空对象）

**`StopBrushService`**
- 修复笔误：原 `yinghua` 分支把 `IsRunning` 设成 `true`，应为 `false`
- 改为统一调用 `(*userActivity).Stop()`，走 Activity 接口正常生命周期，不再直接读写实现字段
- 活动不存在时返回 "任务未启动" 而不是空响应

## Test plan
- [x] 本地 CGO 全量编译验证：`go build ./web/...` 通过
- [x] 前端 `frontend/api/accountApi.ts` 中 `apiClient.post('/v1/startBrush/...')` 与新 POST 路由对齐
- [x] git diff 仅涉及 2 个文件，PR 范围最小化
