### PR TITLE
fix: 邮件发送日志在 fmt.Sprintf 中误用 %w 动词

### DIFF
--- a/utils/EmailUtils.go
+++ b/utils/EmailUtils.go
@@ -41,7 +41,7 @@ func SendMail(host string, port int, userName, password string, toMail []string,
 
 	if err := d.DialAndSend(m); err != nil {
 		//panic(err)
-		lg.Print(lg.INFO, fmt.Sprintf("邮件发送失败-DialAndSend失败: host=%s port=%d user=%s err=%w", host, port, userName, err))
+		lg.Print(lg.INFO, fmt.Sprintf("邮件发送失败-DialAndSend失败: host=%s port=%d user=%s err=%v", host, port, userName, err))
 	}
 }
 


### PR DESCRIPTION
## 背景

`utils/EmailUtils.go:44` 在 `fmt.Sprintf` 中使用了 `%w` 动词，但 Go 的 `%w` 仅 `fmt.Errorf` 支持（用于 error wrapping）。`fmt.Sprintf` 使用 `%w` 不会触发 wrapping，反而会在输出中产生 `%!w(...)` 这种 BAD VERB 占位符，**丢失原始错误信息**。

`go vet` 会直接报错（也是为什么这个项目 `go test ./...` 整体过不去的原因）：

```
utils\EmailUtils.go:44:21: fmt.Sprintf does not support error-wrapping directive %w
```

历史追溯：该行原本是 `panic(err)`，commit `6ffd30d update: 优化英华和海旗` 把它改成日志输出时误用了 `%w`——推测是从 `fmt.Errorf` 的语感带过来的笔误。

## 修改

将 `%w` 改为 `%v`——这是 `fmt.Sprintf` 场景下格式化任意值（包括 error）的标准动词；此处只是写日志输出，不需要 error wrapping 语义。

## Test plan
- [x] 修复前：`go vet ./utils/` 报 `does not support error-wrapping directive %w`
- [x] 修复后：`go vet ./utils/` clean，无任何输出
- [x] `go build ./utils/...` 通过
- [x] 单字符改动，PR diff 最小化
